### PR TITLE
Dispose HTTPClient after disposing buffer sink first.

### DIFF
--- a/src/Serilog.Sinks.MicrosoftTeams/Sinks/MicrosoftTeams/MicrosoftTeamsSink.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams/Sinks/MicrosoftTeams/MicrosoftTeamsSink.cs
@@ -53,8 +53,8 @@ namespace Serilog.Sinks.MicrosoftTeams
         /// <inheritdoc cref="PeriodicBatchingSink"/>
         protected override void Dispose(bool disposing)
         {
-            Client.Dispose();
             base.Dispose(disposing);
+            Client.Dispose();
         }
 
         private MicrosoftTeamsMessageCard CreateMessage(LogEvent logEvent)


### PR DESCRIPTION
This correct the dispose order issue   #4.