### PR TITLE
Add option to disable the rendering of the log properties and render only the message.

### DIFF
--- a/src/Serilog.Sinks.MicrosoftTeams/Sinks/MicrosoftTeams/MicrosoftTeamsSink.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams/Sinks/MicrosoftTeams/MicrosoftTeamsSink.cs
@@ -29,7 +29,7 @@ namespace Serilog.Sinks.MicrosoftTeams
         /// </summary>
         /// <param name="options">Microsoft teams sink options object.</param>
         public MicrosoftTeamsSink(MicrosoftTeamsSinkOptions options)
-                : base(options.BatchSizeLimit, options.Period)
+            : base(options.BatchSizeLimit, options.Period)
         {
             _options = options;
         }
@@ -66,14 +66,16 @@ namespace Serilog.Sinks.MicrosoftTeams
                 Title = _options.Title,
                 Text = renderedMessage,
                 Color = GetAttachmentColor(logEvent.Level),
-                Sections = new[]
-                {
-                    new MicrosoftTeamsMessageSection
+                Sections = _options.RenderProperties
+                    ? new[]
                     {
-                        Title = "Properties",
-                        Facts = GetFacts(logEvent).ToArray()
+                        new MicrosoftTeamsMessageSection
+                        {
+                            Title = "Properties",
+                            Facts = GetFacts(logEvent).ToArray()
+                        }
                     }
-                }
+                    : Enumerable.Empty<MicrosoftTeamsMessageSection>().ToArray()
             };
 
             return request;

--- a/src/Serilog.Sinks.MicrosoftTeams/Sinks/MicrosoftTeams/MicrosoftTeamsSinkOptions.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams/Sinks/MicrosoftTeams/MicrosoftTeamsSinkOptions.cs
@@ -21,8 +21,9 @@ namespace Serilog.Sinks.MicrosoftTeams
         /// <param name="period">The time to wait between checking for event batches; defaults to 1 sec if not
         /// provided.</param>
         /// <param name="formatProvider">The format provider used for formatting the message.</param>
+        /// <param name="renderProperties">Render or not the message properties.</param>
         public MicrosoftTeamsSinkOptions(string webHookUri, string title, int? batchSizeLimit = null,
-            TimeSpan? period = null, IFormatProvider formatProvider = null)
+            TimeSpan? period = null, IFormatProvider formatProvider = null, bool? renderProperties = null)
         {
             if (webHookUri == null)
             {
@@ -39,6 +40,7 @@ namespace Serilog.Sinks.MicrosoftTeams
             BatchSizeLimit = batchSizeLimit ?? DefaultBatchSizeLimit;
             Period = period ?? DefaultPeriod;
             FormatProvider = formatProvider;
+            RenderProperties = renderProperties ?? true;
         }
 
         /// <summary>
@@ -65,5 +67,10 @@ namespace Serilog.Sinks.MicrosoftTeams
         /// The format provider used for formatting the message.
         /// </summary>
         public IFormatProvider FormatProvider { get; }
+
+        /// <summary>
+        /// Render the message properties.
+        /// </summary>
+        public bool RenderProperties { get; }
     }
 }


### PR DESCRIPTION
For now it's not possible to only render the message, so I added an option to disable the rendering of the additional informations. The default behavior remains the same.