### PR TITLE
Feature/upgrade netcore

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A Serilog event sink that writes to [Microsoft Teams](https://teams.microsoft.com).
 
 **Package** - [Serilog.Sinks.MicrosoftTeams](https://www.nuget.org/packages/Serilog.Sinks.MicrosoftTeams/)
-| **Platforms** - .NETStandard 1.1
+| **Platforms** - .NETStandard 2.0
 
 You need to add an "Incoming Webhook" connector to your Teams channel and get it's URL. `title` is optional but can help your distinguish logs coming from different sources.
 

--- a/src/Serilog.Sinks.MicrosoftTeams.Tests/Serilog.Sinks.MicrosoftTeams.Tests.csproj
+++ b/src/Serilog.Sinks.MicrosoftTeams.Tests/Serilog.Sinks.MicrosoftTeams.Tests.csproj
@@ -1,24 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Http.Server" Version="1.1.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-    <PackageReference Include="Serilog" Version="2.4.0" />
-    <PackageReference Include="Shouldly" Version="2.8.3" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Serilog.Sinks.MicrosoftTeams\Serilog.Sinks.MicrosoftTeams.csproj" />
+    <PackageReference Include="Microsoft.Net.Http.Server" Version="1.1.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Serilog.Sinks.MicrosoftTeams\Serilog.Sinks.MicrosoftTeams.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.MicrosoftTeams.Tests/Serilog.Sinks.MicrosoftTeams.Tests.csproj
+++ b/src/Serilog.Sinks.MicrosoftTeams.Tests/Serilog.Sinks.MicrosoftTeams.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Http.Server" Version="1.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Serilog.Sinks.MicrosoftTeams/Serilog.Sinks.MicrosoftTeams.csproj
+++ b/src/Serilog.Sinks.MicrosoftTeams/Serilog.Sinks.MicrosoftTeams.csproj
@@ -20,10 +20,6 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-<!--  <ItemGroup>-->
-<!--    <Compile Include="..\..\AssemblyVersionInfo.cs" Link="Properties\AssemblyVersionInfo.cs" />-->
-<!--  </ItemGroup>-->
-
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Serilog" Version="2.9.0" />

--- a/src/Serilog.Sinks.MicrosoftTeams/Serilog.Sinks.MicrosoftTeams.csproj
+++ b/src/Serilog.Sinks.MicrosoftTeams/Serilog.Sinks.MicrosoftTeams.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.2.0" />

--- a/src/Serilog.Sinks.MicrosoftTeams/Serilog.Sinks.MicrosoftTeams.csproj
+++ b/src/Serilog.Sinks.MicrosoftTeams/Serilog.Sinks.MicrosoftTeams.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Serilog</RootNamespace>
     <Authors>Dmytro Dziuma</Authors>
+    <Version>0.3.0</Version>
     <Company />
     <Description>A Serilog event sink that writes to Microsoft Teams</Description>
     <RepositoryUrl>https://github.com/DixonDs/serilog-sinks-teams</RepositoryUrl>

--- a/src/Serilog.Sinks.MicrosoftTeams/Serilog.Sinks.MicrosoftTeams.csproj
+++ b/src/Serilog.Sinks.MicrosoftTeams/Serilog.Sinks.MicrosoftTeams.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Serilog</RootNamespace>
     <Authors>Dmytro Dziuma</Authors>
     <Company />
@@ -17,16 +17,17 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Copyright>Copyright 2018 (c). All rights reserved.</Copyright>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="..\..\AssemblyVersionInfo.cs" Link="Properties\AssemblyVersionInfo.cs" />
-  </ItemGroup>
+<!--  <ItemGroup>-->
+<!--    <Compile Include="..\..\AssemblyVersionInfo.cs" Link="Properties\AssemblyVersionInfo.cs" />-->
+<!--  </ItemGroup>-->
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-    <PackageReference Include="Serilog" Version="2.4.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.2" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.MicrosoftTeams/Sinks/MicrosoftTeams/MicrosoftTeamsSinkOptions.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams/Sinks/MicrosoftTeams/MicrosoftTeamsSinkOptions.cs
@@ -2,6 +2,8 @@ using System;
 
 namespace Serilog.Sinks.MicrosoftTeams
 {
+    using System.Net.Http;
+
     /// <summary>
     /// Container for all Microsoft Teams sink configurations.
     /// </summary>
@@ -22,7 +24,7 @@ namespace Serilog.Sinks.MicrosoftTeams
         /// provided.</param>
         /// <param name="formatProvider">The format provider used for formatting the message.</param>
         public MicrosoftTeamsSinkOptions(string webHookUri, string title, int? batchSizeLimit = null,
-            TimeSpan? period = null, IFormatProvider formatProvider = null)
+            TimeSpan? period = null, IFormatProvider formatProvider = null, HttpClient httpClient = null)
         {
             if (webHookUri == null)
             {
@@ -39,6 +41,7 @@ namespace Serilog.Sinks.MicrosoftTeams
             BatchSizeLimit = batchSizeLimit ?? DefaultBatchSizeLimit;
             Period = period ?? DefaultPeriod;
             FormatProvider = formatProvider;
+            HttpClient = httpClient;
         }
 
         /// <summary>
@@ -65,5 +68,7 @@ namespace Serilog.Sinks.MicrosoftTeams
         /// The format provider used for formatting the message.
         /// </summary>
         public IFormatProvider FormatProvider { get; }
+        
+        public HttpClient HttpClient { get; }
     }
 }

--- a/src/Serilog.Sinks.MicrosoftTeams/Sinks/MicrosoftTeams/MicrosoftTeamsSinkOptions.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams/Sinks/MicrosoftTeams/MicrosoftTeamsSinkOptions.cs
@@ -23,6 +23,13 @@ namespace Serilog.Sinks.MicrosoftTeams
         /// <param name="period">The time to wait between checking for event batches; defaults to 1 sec if not
         /// provided.</param>
         /// <param name="formatProvider">The format provider used for formatting the message.</param>
+        /// <param name="httpClient">
+        /// The <see cref="HttpClient"/> used by the <see cref="MicrosoftTeamsSink"/> to send the messages.
+        /// If the <see cref="HttpClient"/> is not provided, a private <see cref="HttpClient"/> is created by default.
+        /// </param>
+        /// <remarks>
+        /// If you provide the <paramref name="httpClient"/>, it will not be disposed by the <see cref="MicrosoftTeamsSink"/>.
+        /// </remarks>
         public MicrosoftTeamsSinkOptions(string webHookUri, string title, int? batchSizeLimit = null,
             TimeSpan? period = null, IFormatProvider formatProvider = null, HttpClient httpClient = null)
         {
@@ -69,6 +76,9 @@ namespace Serilog.Sinks.MicrosoftTeams
         /// </summary>
         public IFormatProvider FormatProvider { get; }
         
+        /// <summary>
+        /// The <see cref="HttpClient"/> used by the <see cref="MicrosoftTeamsSink"/> to send the messages.
+        /// </summary>
         public HttpClient HttpClient { get; }
     }
 }


### PR DESCRIPTION
Update the package for the .NET Standard 2.2 and make the lib more robust if an error occurred while sending the batch messages.

Give the opportunity to inject my own `HttpClient `avoiding to create one more `HttpClient` instance.